### PR TITLE
add istioctl view in sidecar level and istiorev view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ cover:  ## Run test coverage suite
 	@go tool cover --html=cov.out
 
 build:  ## Builds the CLI
-	@go build ${GO_FLAGS} \
-	-ldflags "-w -s -X ${PACKAGE}/cmd.version=${VERSION} -X ${PACKAGE}/cmd.commit=${GIT_REV} -X ${PACKAGE}/cmd.date=${DATE}" \
+	@CGO_ENABLED=0 go build ${GO_FLAGS} \
+	-ldflags "-w -s -X ${PACKAGE}/cmd.version=${VERSION} -X ${PACKAGE}/cmd.commit=${GIT_REV} -X ${PACKAGE}/cmd.date=${DATE} -extldflags -static" \
 	-a -tags netgo -o ${OUTPUT_BIN} main.go
+
 
 kubectl-stable-version:  ## Get kubectl latest stable version
 	@curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt

--- a/internal/dao/istioctlView.go
+++ b/internal/dao/istioctlView.go
@@ -1,0 +1,39 @@
+package dao
+
+import (
+	"context"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// IstioctlView
+type IstioctlView struct {
+	NonResource
+}
+
+// List
+func (i IstioctlView) List(ctx context.Context, ns string) ([]runtime.Object, error) {
+	oo := make([]runtime.Object, 0)
+	// "iptables -t nat -S",
+	command := []string{
+		"istioctl version",
+		"istioctl admin log",
+		"istioctl profile list",
+		"istioctl operator dump",
+		"istioctl x revision list",
+		"istioctl x config list",
+		"istioctl x injector list",
+		"istioctl x precheck",
+	}
+
+	parent, ok := ctx.Value("parent").(string)
+	if !ok {
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value("parent"))
+		return oo, nil
+	}
+	for _, f := range command {
+		oo = append(oo, render.IstioctlViewRes{Name: f, Parent: parent})
+	}
+	return oo, nil
+}

--- a/internal/dao/proxy_info.go
+++ b/internal/dao/proxy_info.go
@@ -1,0 +1,41 @@
+package dao
+
+import (
+	"context"
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ProxyInfoEx
+type ProxyInfo struct {
+	NonResource
+}
+
+// List
+func (i ProxyInfo) List(ctx context.Context, ns string) ([]runtime.Object, error) {
+	oo := make([]runtime.Object, 0)
+	// "iptables -t nat -S",
+	command := []string{
+		"istioctl proxy-status",
+		"istioctl proxy-config bootstrap",
+		"istioctl proxy-config cluster",
+		"istioctl proxy-config all",
+		"istioctl proxy-config endpoints",
+		"istioctl proxy-config listener",
+		"istioctl proxy-config log",
+		"istioctl proxy-config route",
+	}
+
+	path, ok := ctx.Value(internal.KeyPath).(string)
+	if !ok {
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value("path"))
+		return oo, nil
+	}
+
+	for _, f := range command {
+		oo = append(oo, render.ProxyInfoRes{Name: f, Parent: path})
+	}
+	return oo, nil
+}

--- a/internal/dao/proxy_info_ex.go
+++ b/internal/dao/proxy_info_ex.go
@@ -8,16 +8,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// IptableInfo
-type IptableInfo struct {
+// ProxyInfo
+type ProxyInfoEx struct {
 	NonResource
 }
 
 // List
-func (i IptableInfo) List(ctx context.Context, ns string) ([]runtime.Object, error) {
+func (i ProxyInfoEx) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	oo := make([]runtime.Object, 0)
+	// "iptables -t nat -S",
 	command := []string{
-		"IptableInfo",
+		"iptables rule",
 	}
 
 	path, ok := ctx.Value(internal.KeyPath).(string)
@@ -27,7 +28,7 @@ func (i IptableInfo) List(ctx context.Context, ns string) ([]runtime.Object, err
 	}
 
 	for _, f := range command {
-		oo = append(oo, render.IptableInfoRes{Name: f, Parent: path})
+		oo = append(oo, render.ProxyInfoExRes{Name: f, Parent: path})
 	}
 	return oo, nil
 }

--- a/internal/dao/registry_i9s.go
+++ b/internal/dao/registry_i9s.go
@@ -69,10 +69,24 @@ func loadi9s(m ResourceMetas) {
 		Verbs:        []string{},
 		Categories:   []string{"k9s"},
 	}
-	m[client.NewGVR("iptableInfo")] = metav1.APIResource{
-		Name:         "iptableInfo",
-		Kind:         "iptableInfo",
-		SingularName: "iptableInfo",
+	m[client.NewGVR("proxyInfo")] = metav1.APIResource{
+		Name:         "proxyInfo",
+		Kind:         "proxyInfo",
+		SingularName: "proxyInfo",
+		Verbs:        []string{},
+		Categories:   []string{"k9s"},
+	}
+	m[client.NewGVR("proxyInfoEx")] = metav1.APIResource{
+		Name:         "proxyInfoEx",
+		Kind:         "proxyInfoEx",
+		SingularName: "proxyInfoEx",
+		Verbs:        []string{},
+		Categories:   []string{"k9s"},
+	}
+	m[client.NewGVR("istioctlView")] = metav1.APIResource{
+		Name:         "istioctlView",
+		Kind:         "istioctlView",
+		SingularName: "istioctlView",
 		Verbs:        []string{},
 		Categories:   []string{"k9s"},
 	}

--- a/internal/model/registry_i9s.go
+++ b/internal/model/registry_i9s.go
@@ -7,43 +7,51 @@ import (
 
 func init() {
 	Registry["istio"] = ResourceMeta{
-		DAO:          &dao.Istio{},
-		Renderer:     &render.Istio{},
+		DAO:      &dao.Istio{},
+		Renderer: &render.Istio{},
 	}
 	Registry["eda"] = ResourceMeta{
-		DAO:          &dao.EnvoyApi{},
-		Renderer:     &render.EnvoyApi{},
+		DAO:      &dao.EnvoyApi{},
+		Renderer: &render.EnvoyApi{},
 	}
 	Registry["ic"] = ResourceMeta{
-		DAO:          &dao.IstioConfig{},
-		Renderer:     &render.IstioConfig{},
+		DAO:      &dao.IstioConfig{},
+		Renderer: &render.IstioConfig{},
 	}
 	Registry["ida"] = ResourceMeta{
-		DAO:          &dao.IstioApi{},
-		Renderer:     &render.IstioApi{},
+		DAO:      &dao.IstioApi{},
+		Renderer: &render.IstioApi{},
 	}
 	Registry["pilot"] = ResourceMeta{
-		DAO:          &dao.IstioPilot{},
-		Renderer:     &render.IstioPilot{},
+		DAO:      &dao.IstioPilot{},
+		Renderer: &render.IstioPilot{},
 	}
 	Registry["proxyID"] = ResourceMeta{
-		DAO:          &dao.IstioProxyID{},
-		Renderer:     &render.IstioProxyID{},
+		DAO:      &dao.IstioProxyID{},
+		Renderer: &render.IstioProxyID{},
 	}
 	Registry["xps"] = ResourceMeta{
-		DAO:          &dao.IstioXdsPushStats{},
-		Renderer:     &render.IstioXdsPushStats{},
+		DAO:      &dao.IstioXdsPushStats{},
+		Renderer: &render.IstioXdsPushStats{},
 	}
 	Registry["configz"] = ResourceMeta{
-		DAO:          &dao.IstioConfigz{},
-		Renderer:     &render.IstioConfigz{},
+		DAO:      &dao.IstioConfigz{},
+		Renderer: &render.IstioConfigz{},
 	}
 	Registry["adsz"] = ResourceMeta{
-		DAO:          &dao.IstioAdsz{},
-		Renderer:     &render.IstioAdsz{},
+		DAO:      &dao.IstioAdsz{},
+		Renderer: &render.IstioAdsz{},
 	}
-	Registry["iptableInfo"] = ResourceMeta{
-		DAO:          &dao.IptableInfo{},
-		Renderer:     &render.IptableInfo{},
+	Registry["proxyInfo"] = ResourceMeta{
+		DAO:      &dao.ProxyInfo{},
+		Renderer: &render.ProxyInfo{},
+	}
+	Registry["proxyInfoEx"] = ResourceMeta{
+		DAO:      &dao.ProxyInfoEx{},
+		Renderer: &render.ProxyInfoEx{},
+	}
+	Registry["istioctlView"] = ResourceMeta{
+		DAO:      &dao.IstioctlView{},
+		Renderer: &render.IstioctlView{},
 	}
 }

--- a/internal/render/istioctlView.go
+++ b/internal/render/istioctlView.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 )
 
-type IptableInfo struct{}
+type IstioctlView struct{}
 
-func (i IptableInfo) IsGeneric() bool {
+func (i IstioctlView) IsGeneric() bool {
 	return false
 }
 
-func (i IptableInfo) Render(o interface{}, ns string, r *Row) error {
+func (i IstioctlView) Render(o interface{}, ns string, r *Row) error {
 
-	res, ok := o.(IptableInfoRes)
+	res, ok := o.(IstioctlViewRes)
 	if !ok {
 		return fmt.Errorf("expected EnvoyAPIRes, but got %T", o)
 	}
@@ -25,30 +25,29 @@ func (i IptableInfo) Render(o interface{}, ns string, r *Row) error {
 	return nil
 }
 
-func (i IptableInfo) Header(ns string) Header {
+func (i IstioctlView) Header(ns string) Header {
 	return Header{
-		HeaderColumn{Name: "iptableInfo"},
+		HeaderColumn{Name: "istioctl command items"},
 	}
 }
 
-func (i IptableInfo) ColorerFunc() ColorerFunc {
+func (i IstioctlView) ColorerFunc() ColorerFunc {
 	return func(ns string, _ Header, re RowEvent) tcell.Color {
 		return tcell.ColorCadetBlue
 	}
 }
 
-// EnvoyAPIRes represents an envoy debug api resource.
-type IptableInfoRes struct {
-	Name string
+type IstioctlViewRes struct {
+	Name   string
 	Parent string
 }
 
 // GetObjectKind returns a schema object.
-func (IptableInfoRes) GetObjectKind() schema.ObjectKind {
+func (IstioctlViewRes) GetObjectKind() schema.ObjectKind {
 	return nil
 }
 
 // DeepCopyObject returns a container copy.
-func (h IptableInfoRes) DeepCopyObject() runtime.Object {
+func (h IstioctlViewRes) DeepCopyObject() runtime.Object {
 	return h
 }

--- a/internal/render/proxy_Info.go
+++ b/internal/render/proxy_Info.go
@@ -1,0 +1,53 @@
+package render
+
+import (
+	"fmt"
+	"github.com/gdamore/tcell/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"strings"
+)
+
+type ProxyInfo struct{}
+
+func (i ProxyInfo) IsGeneric() bool {
+	return false
+}
+
+func (i ProxyInfo) Render(o interface{}, ns string, r *Row) error {
+
+	res, ok := o.(ProxyInfoRes)
+	if !ok {
+		return fmt.Errorf("expected ProxyInfoRes, but got %T", o)
+	}
+	id := strings.Join([]string{res.Parent, res.Name}, "#")
+	r.ID, r.Fields = id, append(r.Fields, res.Name)
+	return nil
+}
+
+func (i ProxyInfo) Header(ns string) Header {
+	return Header{
+		HeaderColumn{Name: "istioctl command items"},
+	}
+}
+
+func (i ProxyInfo) ColorerFunc() ColorerFunc {
+	return func(ns string, _ Header, re RowEvent) tcell.Color {
+		return tcell.ColorCadetBlue
+	}
+}
+
+type ProxyInfoRes struct {
+	Name   string
+	Parent string
+}
+
+// GetObjectKind returns a schema object.
+func (ProxyInfoRes) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+// DeepCopyObject returns a container copy.
+func (h ProxyInfoRes) DeepCopyObject() runtime.Object {
+	return h
+}

--- a/internal/render/proxy_Info_ex.go
+++ b/internal/render/proxy_Info_ex.go
@@ -1,0 +1,53 @@
+package render
+
+import (
+	"fmt"
+	"github.com/gdamore/tcell/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"strings"
+)
+
+type ProxyInfoEx struct{}
+
+func (i ProxyInfoEx) IsGeneric() bool {
+	return false
+}
+
+func (i ProxyInfoEx) Render(o interface{}, ns string, r *Row) error {
+
+	res, ok := o.(ProxyInfoExRes)
+	if !ok {
+		return fmt.Errorf("expected ProxyInfoEx, but got %T", o)
+	}
+	id := strings.Join([]string{res.Parent, res.Name}, "#")
+	r.ID, r.Fields = id, append(r.Fields, res.Name)
+	return nil
+}
+
+func (i ProxyInfoEx) Header(ns string) Header {
+	return Header{
+		HeaderColumn{Name: "Ex"},
+	}
+}
+
+func (i ProxyInfoEx) ColorerFunc() ColorerFunc {
+	return func(ns string, _ Header, re RowEvent) tcell.Color {
+		return tcell.ColorCadetBlue
+	}
+}
+
+type ProxyInfoExRes struct {
+	Name   string
+	Parent string
+}
+
+// GetObjectKind returns a schema object.
+func (ProxyInfoExRes) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+// DeepCopyObject returns a container copy.
+func (h ProxyInfoExRes) DeepCopyObject() runtime.Object {
+	return h
+}

--- a/internal/view/istio_view.go
+++ b/internal/view/istio_view.go
@@ -1,0 +1,80 @@
+package view
+
+import (
+	"context"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rs/zerolog/log"
+)
+
+type IstioView struct {
+	ResourceViewer
+}
+
+func NewIstio(gvr client.GVR) ResourceViewer {
+	c := IstioView{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	c.GetTable().SetColorerFn(render.Istio{}.ColorerFunc())
+	c.GetTable().SetBorderFocusColor(tcell.ColorMediumSpringGreen)
+	c.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorMediumSpringGreen).Attributes(tcell.AttrNone))
+	c.AddBindKeysFn(c.bindKeys)
+	c.SetContextFn(c.chartContext)
+	c.GetTable().SetEnterFn(c.showIstioConfig)
+	return &c
+}
+
+func (i *IstioView) chartContext(ctx context.Context) context.Context {
+	rev := i.GetTable().GetSelectedItem()
+	return context.WithValue(ctx, "parent", rev)
+}
+
+func (i *IstioView) bindKeys(aa ui.KeyActions) {
+	aa.Add(ui.KeyActions{
+		ui.KeyM: ui.NewKeyAction("Istio debug api view", i.istioDebugApi, true),
+		//ui.KeyB: ui.NewKeyAction("istio config", i.showIstioConfig, true),
+		ui.KeyN: ui.NewKeyAction("Istioctl view", i.istioctlView, true),
+	})
+}
+
+func (i *IstioView) istioDebugApi(evt *tcell.EventKey) *tcell.EventKey {
+	sel := i.GetTable().GetSelectedItem()
+	log.Debug().Msgf("get sel %s in debug", sel)
+	if sel == "" {
+		return evt
+	}
+	ida := NewIstioApiView(client.NewGVR("ida"))
+	ida.SetContextFn(i.chartContext)
+	if err := i.App().inject(ida); err != nil {
+		i.App().Flash().Err(err)
+		return evt
+	}
+	return nil
+}
+
+func (i *IstioView) showIstioConfig(app *App, model ui.Tabular, gvr, path string) {
+	//sel := i.GetTable().GetSelectedItem()
+	//log.Info().Msgf("get sel %s in debug in showIstioConfig ", sel)
+	ic := NewIstioConfigView(client.NewGVR("ic"))
+	ic.SetContextFn(i.chartContext)
+	if err := i.App().inject(ic); err != nil {
+		i.App().Flash().Err(err)
+	}
+}
+
+func (i *IstioView) istioctlView(evt *tcell.EventKey) *tcell.EventKey {
+	sel := i.GetTable().GetSelectedItem()
+	log.Debug().Msgf("get sel %s in debug", sel)
+	if sel == "" {
+		return evt
+	}
+	iview := NewIstioctlView(client.NewGVR("istioctlView"))
+	iview.SetContextFn(i.chartContext)
+	if err := i.App().inject(iview); err != nil {
+		i.App().Flash().Err(err)
+		return evt
+	}
+	return nil
+}

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -72,10 +72,11 @@ func (p *Pod) bindKeys(aa ui.KeyActions) {
 	if !p.App().Config.K9s.IsReadOnly() {
 		p.bindDangerousKeys(aa)
 	}
-   aa.Add(ui.KeyActions{
-   	    ui.KeyM: ui.NewKeyAction("Envoy Debug", p.showProxyConfig,true),
-	    ui.KeyN: ui.NewKeyAction("IptableInfo", p.showProxyIptableInfo,true),
-   })
+	aa.Add(ui.KeyActions{
+		ui.KeyM: ui.NewKeyAction("Envoy debug api view", p.showProxyConfig, true),
+		ui.KeyN: ui.NewKeyAction("Istioctl view", p.showProxyInfo, true),
+		ui.KeyB: ui.NewKeyAction("ProxyEx view", p.showProxyInfoEx, true),
+	})
 	aa.Add(ui.KeyActions{
 		ui.KeyF:      ui.NewKeyAction("Show PortForward", p.showPFCmd, true),
 		ui.KeyShiftR: ui.NewKeyAction("Sort Ready", p.GetTable().SortColCmd(readyCol, true), false),

--- a/internal/view/pod_i9s.go
+++ b/internal/view/pod_i9s.go
@@ -31,7 +31,7 @@ func (p *Pod) showProxyConfig(evt *tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
-func (p *Pod) showProxyIptableInfo(evt *tcell.EventKey) *tcell.EventKey {
+func (p *Pod) showProxyInfo(evt *tcell.EventKey) *tcell.EventKey {
 
 	path := p.GetTable().GetSelectedItem()
 	//log.Info().Msgf("get pods %s in showProxyMetaInfo", path)
@@ -44,7 +44,7 @@ func (p *Pod) showProxyIptableInfo(evt *tcell.EventKey) *tcell.EventKey {
 		return nil
 	}
 
-	info := NewIptableInfoView(client.NewGVR("iptableInfo"))
+	info := NewProxyInfoView(client.NewGVR("proxyInfo"))
 	info.SetContextFn(p.coContext)
 	if err := p.App().inject(info); err != nil {
 		p.App().Flash().Err(err)
@@ -53,6 +53,27 @@ func (p *Pod) showProxyIptableInfo(evt *tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
+func (p *Pod) showProxyInfoEx(evt *tcell.EventKey) *tcell.EventKey {
+
+	path := p.GetTable().GetSelectedItem()
+	//log.Info().Msgf("get pods %s in showProxyMetaInfo", path)
+	if path == "" {
+		return evt
+	}
+
+	if !p.containProxy() {
+		log.Debug().Msgf("pod %s has no istio-proxy, skip", path)
+		return nil
+	}
+
+	info := NewProxyinfoExView(client.NewGVR("proxyInfoEx"))
+	info.SetContextFn(p.coContext)
+	if err := p.App().inject(info); err != nil {
+		p.App().Flash().Err(err)
+		return evt
+	}
+	return nil
+}
 
 func (p *Pod) containProxy() bool {
 	path := p.GetTable().GetSelectedItem()

--- a/internal/view/proxyInfo.go
+++ b/internal/view/proxyInfo.go
@@ -1,0 +1,66 @@
+package view
+
+import (
+	"context"
+	"fmt"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rs/zerolog/log"
+	"strings"
+)
+
+type ProxyinfoView struct {
+	ResourceViewer
+}
+
+func NewProxyInfoView(gvr client.GVR) ResourceViewer {
+	c := ProxyinfoView{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	c.GetTable().SetColorerFn(render.ProxyInfo{}.ColorerFunc())
+	c.GetTable().SetBorderFocusColor(tcell.ColorMediumSpringGreen)
+	c.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorMediumSpringGreen).Attributes(tcell.AttrNone))
+	c.SetContextFn(c.chartContext)
+	c.GetTable().SetEnterFn(c.enter)
+	return &c
+}
+
+func (i *ProxyinfoView) chartContext(ctx context.Context) context.Context {
+	return ctx
+}
+
+func (i *ProxyinfoView) enter(app *App, model ui.Tabular, gvr, path string) {
+
+	path, cf, err := parseInfoView(path)
+	if err != nil {
+		log.Error().Msgf("get error in parseIptableInfoView, %s", err)
+		return
+	}
+	if strings.HasPrefix(cf, "istioctl") {
+		i.istioctlProxyCmd(cf, path)
+	}
+}
+
+func (c *ProxyinfoView) istioctlProxyCmd(cf, path string) {
+
+	namespace, name := client.Namespaced(path)
+	cmd := fmt.Sprintf("%s %s.%s | less", cf, name, namespace)
+
+	log.Info().Msgf("prepare exec cmd: %s", cmd)
+	cb := func() {
+		opts := shellOpts{
+			clear:      false,
+			binary:     "sh",
+			background: false,
+			args:       []string{"-c", cmd},
+		}
+		if run(c.App(), opts) {
+			c.App().Flash().Info("command launched successfully in proxyInfo!")
+			return
+		}
+		c.App().Flash().Info("command failed in proxyInfo!")
+	}
+	cb()
+}

--- a/internal/view/registrar.go
+++ b/internal/view/registrar.go
@@ -103,6 +103,9 @@ func miscViewers(vv MetaViewers) {
 	vv[client.NewGVR("ic")] = MetaViewer{
 		viewerFn: NewIstioConfigView,
 	}
+	vv[client.NewGVR("istioctlView")] = MetaViewer{
+		viewerFn: NewIstioctlView,
+	}
 }
 
 func appsViewers(vv MetaViewers) {


### PR DESCRIPTION
some functions of istioctl can be used directly in i9s, reducing the amount of development in i9s

1. add istioctl veiw in per pods 

 select pods and enter `n`

![image](https://user-images.githubusercontent.com/31659110/198921545-7052c863-9d6e-486f-ae31-733678527477.png)

2. add istioctl veiw in per pods 

 select rev and enter `n`

![image](https://user-images.githubusercontent.com/31659110/198921618-3fead8d7-dc59-4475-bae0-ec5b7a1b29f8.png)

