### PR TITLE
support specify custom command in extension view

### DIFF
--- a/internal/config/extension_i9s.go
+++ b/internal/config/extension_i9s.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"strings"
+)
+
+var ViewToExtension = make(map[string][]Extension)
+
+// usage:
+
+//var LocalExtensions = `extensions:
+//- view: istioView
+//  name: rev-reset
+//  command: sh
+//  args:
+//  - "cmd reset--rev $ISTIO_REV"
+//- view: istioView
+//  name: echo
+//  command: sh
+//  args:
+//  - "echo $ISTIO_REV"
+//- view: sidecarView
+//  name: describe
+//  command: sh
+//  args:
+//  - "kubectl describe pods $NAME -n $NAMESPACE"
+//`
+
+var LocalExtensions = ``
+
+type Extensions struct {
+	Extension []Extension `yaml:"extensions"`
+}
+
+type Extension struct {
+	View    string   `yaml:"view"`
+	Name    string   `yaml:"name"`
+	Args    []string `yaml:"args"`
+	Command string   `yaml:"command"`
+}
+
+func (p Extension) String() string {
+	return fmt.Sprintf("[%s-%s] %s(%s)", p.View, p.Name, p.Command, strings.Join(p.Args, " "))
+}
+
+func init() {
+	LoadExtensions()
+}
+
+func LoadExtensions() {
+	var pp Extensions
+	if err := yaml.Unmarshal([]byte(LocalExtensions), &pp); err != nil {
+		return
+	}
+	for _, v := range pp.Extension {
+		if _, ok := ViewToExtension[v.View]; !ok {
+			ViewToExtension[v.View] = make([]Extension, 0)
+		}
+		ViewToExtension[v.View] = append(ViewToExtension[v.View], v)
+	}
+}

--- a/internal/dao/i9s_extension.go
+++ b/internal/dao/i9s_extension.go
@@ -1,0 +1,50 @@
+package dao
+
+import (
+	"context"
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/runtime"
+	"strings"
+)
+
+type I9sExtension struct {
+	NonResource
+}
+
+// List
+func (i I9sExtension) List(ctx context.Context, ns string) ([]runtime.Object, error) {
+	oo := make([]runtime.Object, 0)
+
+	typ, ok := ctx.Value(internal.ExtensionType).(string)
+	if !ok {
+		log.Error().Msgf("want to get stirng extensionType, but get %T", ctx.Value(internal.ExtensionType))
+		return oo, nil
+	}
+	log.Info().Msgf("get typ %s", typ)
+	command := getCommand(string(typ))
+	log.Info().Msgf("get command %+v", command)
+	parent, ok := ctx.Value(internal.IstioRev).(string)
+	if !ok {
+		log.Error().Msgf("want to get stirng extensionType, but get %T", ctx.Value(internal.IstioRev))
+		return oo, nil
+	}
+
+	for _, f := range command {
+		oo = append(oo, render.I9sExtensionRes{Name: f, Parent: string(parent)})
+	}
+	return oo, nil
+}
+
+func getCommand(typ string) []string {
+
+	var cmds []string
+
+	arr := config.ViewToExtension[typ]
+	for i, _ := range arr {
+		cmds = append(cmds, strings.Join(arr[i].Args, " "))
+	}
+	return cmds
+}

--- a/internal/dao/istio_config.go
+++ b/internal/dao/istio_config.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,9 +22,9 @@ func (i IstioConfig) List(ctx context.Context, ns string) ([]runtime.Object, err
 		"Istiod Deployment Manifest",
 	}
 
-	parent, ok := ctx.Value("parent").(string)
+	parent, ok := ctx.Value(internal.Parent).(string)
 	if !ok {
-		log.Error().Msgf("Expecting a string but got %T", ctx.Value("parent"))
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value(internal.Parent))
 		return oo, nil
 	}
 

--- a/internal/dao/istio_configz.go
+++ b/internal/dao/istio_configz.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
@@ -23,9 +24,9 @@ type IstioConfigz struct {
 func (i IstioConfigz) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	oo := make([]runtime.Object, 0)
 
-	parent, ok := ctx.Value("parent").(string)
+	parent, ok := ctx.Value(internal.Parent).(string)
 	if !ok {
-		log.Error().Msgf("Expecting a string but got %T", ctx.Value("parent"))
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value(internal.Parent))
 		return oo, nil
 	}
 	rev, _ := parse(parent)
@@ -33,15 +34,15 @@ func (i IstioConfigz) List(ctx context.Context, ns string) ([]runtime.Object, er
 	if name == "" || namespace == "" {
 		return oo, nil
 	}
-	c := getConfigz(namespace,name)
+	c := getConfigz(namespace, name)
 	items := parseConfigz(c)
 	if len(items) > 0 {
 		for _, item := range items {
 			oo = append(oo, render.IstioConfigzRes{
-				Name: item.Metadata.Name,
+				Name:      item.Metadata.Name,
 				Namespace: item.Metadata.Namespace,
-				Kind: item.Kind,
-				Parent: strings.Join([]string{namespace, name}, "#") ,
+				Kind:      item.Kind,
+				Parent:    strings.Join([]string{namespace, name}, "#"),
 			})
 		}
 	}
@@ -49,12 +50,12 @@ func (i IstioConfigz) List(ctx context.Context, ns string) ([]runtime.Object, er
 }
 
 type Configz struct {
-	Kind string `json:"kind"`
+	Kind     string   `json:"kind"`
 	Metadata MetaData `json:"metadata"`
 }
 
 type MetaData struct {
-	Name string `json:"name"`
+	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 }
 
@@ -91,8 +92,7 @@ func (i *IstioConfigz) getPilotNameNamespace(rev string) (string, string) {
 		if err != nil {
 			return "", ""
 		}
-		return  po.Namespace, po.Name
+		return po.Namespace, po.Name
 	}
 	return "", ""
 }
-

--- a/internal/dao/istio_debug_api.go
+++ b/internal/dao/istio_debug_api.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,9 +42,9 @@ func (i IstioApi) List(ctx context.Context, ns string) ([]runtime.Object, error)
 		"istio/configzEx",
 		"istio/adszEx",
 	}
-	parent, ok := ctx.Value("parent").(string)
+	parent, ok := ctx.Value(internal.Parent).(string)
 	if !ok {
-		log.Error().Msgf("Expecting a string but got %T", ctx.Value("parent"))
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value(internal.Parent))
 		return oo, nil
 	}
 	for _, f := range command {

--- a/internal/dao/istio_pilot.go
+++ b/internal/dao/istio_pilot.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
@@ -20,9 +21,9 @@ type IstioPilot struct {
 func (i IstioPilot) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	oo := make([]runtime.Object, 0)
 	//   112#istio/sidecarz
-	parent, ok := ctx.Value("parent").(string)
+	parent, ok := ctx.Value(internal.Parent).(string)
 	if !ok {
-		log.Error().Msgf("Expecting a string but got %T", ctx.Value("parent"))
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value(internal.Parent))
 		return oo, nil
 	}
 	// log.Info().Msgf("get parent %s in dao istio_pilot", parent)

--- a/internal/dao/istio_proxyID.go
+++ b/internal/dao/istio_proxyID.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"context"
 	"encoding/json"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,9 +27,9 @@ func (i IstioProxyID) List(ctx context.Context, ns string) ([]runtime.Object, er
 	// 用conetxt 传递 jso
 	// 112#istio/sidecarz#istio-system/pilot-1 => value
 	// json
-	parent, ok := ctx.Value("parent").(string)
+	parent, ok := ctx.Value(internal.Parent).(string)
 	if !ok {
-		log.Error().Msgf("Expecting a string but got %T", ctx.Value("parent"))
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value(internal.Parent))
 		return oo, nil
 	}
 	//log.Info().Msgf("get parent %s in dao IstioProxyID", parent)

--- a/internal/dao/istio_xds_push_stats.go
+++ b/internal/dao/istio_xds_push_stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/render"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prom2json"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"time"
 )
+
 var pre = make(map[string]string)
 
 type IstioXdsPushStats struct {
@@ -27,9 +29,9 @@ func (i IstioXdsPushStats) List(ctx context.Context, ns string) ([]runtime.Objec
 	now := time.Now()
 	log.Debug().Msgf("begin time is %s", now.String())
 
-	parent, ok := ctx.Value("parent").(string)
+	parent, ok := ctx.Value(internal.Parent).(string)
 	if !ok {
-		log.Error().Msgf("Expecting a string but got %T", ctx.Value("parent"))
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value(internal.Parent))
 		return oo, nil
 	}
 
@@ -55,7 +57,7 @@ func (i IstioXdsPushStats) List(ctx context.Context, ns string) ([]runtime.Objec
 		for k, v := range metrics {
 			newVal := toNum(v)
 			oldVal := toNum(pre[k])
-			res[k] =  strconv.Itoa(newVal-oldVal)
+			res[k] = strconv.Itoa(newVal - oldVal)
 		}
 		pre = metrics
 	}
@@ -66,7 +68,6 @@ func (i IstioXdsPushStats) List(ctx context.Context, ns string) ([]runtime.Objec
 	}
 	return oo, nil
 }
-
 
 func parseMetrics(content string) map[string]string {
 	mfChan := make(chan *dto.MetricFamily, 1024)

--- a/internal/dao/istioctlView.go
+++ b/internal/dao/istioctlView.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,9 +28,9 @@ func (i IstioctlView) List(ctx context.Context, ns string) ([]runtime.Object, er
 		"istioctl x precheck",
 	}
 
-	parent, ok := ctx.Value("parent").(string)
+	parent, ok := ctx.Value(internal.Parent).(string)
 	if !ok {
-		log.Error().Msgf("Expecting a string but got %T", ctx.Value("parent"))
+		log.Error().Msgf("Expecting a string but got %T", ctx.Value(internal.Parent))
 		return oo, nil
 	}
 	for _, f := range command {

--- a/internal/dao/registry_i9s.go
+++ b/internal/dao/registry_i9s.go
@@ -97,4 +97,11 @@ func loadi9s(m ResourceMetas) {
 		Verbs:        []string{},
 		Categories:   []string{"k9s"},
 	}
+	m[client.NewGVR("i9sExtension")] = metav1.APIResource{
+		Name:         "i9sExtension",
+		Kind:         "i9sExtension",
+		SingularName: "i9sExtension",
+		Verbs:        []string{},
+		Categories:   []string{"k9s"},
+	}
 }

--- a/internal/keys.go
+++ b/internal/keys.go
@@ -30,4 +30,7 @@ const (
 	KeyWithMetrics ContextKey = "withMetrics"
 	KeyViewConfig  ContextKey = "viewConfig"
 	KeyWait        ContextKey = "wait"
+	ExtensionType  ContextKey = "extensionType"
+	IstioRev       ContextKey = "rev"
+	Parent         ContextKey = "istioParent"
 )

--- a/internal/model/registry_i9s.go
+++ b/internal/model/registry_i9s.go
@@ -58,4 +58,8 @@ func init() {
 		DAO:      &dao.IstioctlView{},
 		Renderer: &render.IstioctlView{},
 	}
+	Registry["i9sExtension"] = ResourceMeta{
+		DAO:      &dao.I9sExtension{},
+		Renderer: &render.I9sExtension{},
+	}
 }

--- a/internal/render/i9s_extension.go
+++ b/internal/render/i9s_extension.go
@@ -1,0 +1,54 @@
+package render
+
+import (
+	"fmt"
+	"github.com/gdamore/tcell/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"strings"
+)
+
+type I9sExtension struct{}
+
+func (i I9sExtension) IsGeneric() bool {
+	return false
+}
+
+func (i I9sExtension) Render(o interface{}, ns string, r *Row) error {
+
+	res, ok := o.(I9sExtensionRes)
+	if !ok {
+		return fmt.Errorf("expected I9sExtensionRes, but got %T", o)
+	}
+	id := strings.Join([]string{res.Parent, res.Name}, "#")
+	r.ID, r.Fields = id, append(r.Fields, res.Name)
+	return nil
+}
+
+func (i I9sExtension) Header(ns string) Header {
+	return Header{
+		HeaderColumn{Name: "EXTENSION COMMAND"},
+	}
+}
+
+func (i I9sExtension) ColorerFunc() ColorerFunc {
+	return func(ns string, _ Header, re RowEvent) tcell.Color {
+		return tcell.ColorCadetBlue
+	}
+}
+
+type I9sExtensionRes struct {
+	Name   string
+	Rev    string
+	Parent string
+}
+
+// GetObjectKind returns a schema object.
+func (i I9sExtensionRes) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+// DeepCopyObject returns a container copy.
+func (i I9sExtensionRes) DeepCopyObject() runtime.Object {
+	return i
+}

--- a/internal/view.go
+++ b/internal/view.go
@@ -1,0 +1,6 @@
+package internal
+
+const (
+	IstioView   = "istioView"
+	SidecarView = "sidecarView"
+)

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -109,6 +109,7 @@ func pluginActions(r Runner, aa ui.KeyActions) {
 			pluginAction(r, plugin),
 			true)
 	}
+
 }
 
 func pluginAction(r Runner, p config.Plugin) ui.ActionHandler {

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -480,7 +480,6 @@ func (b *Browser) refreshActions() {
 		aa[ui.KeyY] = ui.NewKeyAction("YAML", b.viewCmd, true)
 		aa[ui.KeyD] = ui.NewKeyAction("Describe", b.describeCmd, true)
 	}
-
 	pluginActions(b, aa)
 	hotKeyActions(b, aa)
 	for _, f := range b.bindKeysFn {

--- a/internal/view/i9s_extension.go
+++ b/internal/view/i9s_extension.go
@@ -1,0 +1,98 @@
+package view
+
+import (
+	"context"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rs/zerolog/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os/exec"
+	"strings"
+)
+
+type I9sExtensionView struct {
+	ResourceViewer
+}
+
+func NewI9sExtensionView(gvr client.GVR) ResourceViewer {
+	c := I9sExtensionView{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	c.GetTable().SetColorerFn(render.I9sExtension{}.ColorerFunc())
+	c.GetTable().SetBorderFocusColor(tcell.ColorMediumSpringGreen)
+	c.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorMediumSpringGreen).Attributes(tcell.AttrNone))
+	c.SetContextFn(c.chartContext)
+	c.GetTable().SetEnterFn(c.enter)
+
+	return &c
+}
+
+func (i *I9sExtensionView) chartContext(ctx context.Context) context.Context {
+	return ctx
+}
+
+func (i *I9sExtensionView) enter(app *App, model ui.Tabular, gvr, path string) {
+	env := i.GetTable().envFn()
+	log.Debug().Msgf("get env %+v", env)
+
+	cmd := i.fillEnv(env)
+	cmd, err := env.Substitute(cmd)
+
+	if err != nil {
+		log.Error().Err(err).Msg("Plugin Args match failed")
+	}
+	log.Info().Msgf("get cmd in i9s extension view:  %s", cmd)
+
+	out, err := exec.Command("sh", []string{"-c", cmd}...).Output()
+	if err != nil {
+		log.Error().Msgf("exe cmd err, %s", err)
+		return
+	}
+	view := NewDetails(i.App(), "I9s Extension", "Extension", true).Update(string(out))
+	if err := i.App().inject(view); err != nil {
+		i.App().Flash().Err(err)
+	}
+}
+
+func (i *I9sExtensionView) fillEnv(env map[string]string) string {
+	// NAME:default#cmd reset --rev ${ISTIO_REV}
+	// NAME:details-v1-7d88846999-lz7ts#kubectl describe pods ${NAME} -n ${NAMESPACE}
+	name := env["NAME"]
+	parts := strings.Split(name, "#")
+	if len(parts) != 2 {
+		return ""
+	}
+	env["ISTIO_REV"] = parts[0]
+	env["NAME"] = parts[0]
+
+	if env["NAMESPACE"] == "" {
+		if ns := i.getDeploymentNs(parts[0]); ns != "" {
+			env["NAMESPACE"] = ns
+
+		}
+	}
+	return parts[1]
+}
+
+func (i *I9sExtensionView) getDeploymentNs(rev string) string {
+
+	dial, err := i.App().factory.Client().Dial()
+	if err != nil {
+		log.Error().Msgf("get client err in view i9s_extension, %s", err)
+	}
+	dps, err := dial.AppsV1().Deployments("").
+		List(context.TODO(), metav1.ListOptions{
+			LabelSelector: toSelector(map[string]string{"app": "istiod", "istio.io/rev": rev}),
+		})
+	if err != nil {
+		log.Error().Msgf("list deployment err, %s", err)
+		return ""
+	}
+
+	if len(dps.Items) > 0 {
+		return dps.Items[0].Namespace
+	}
+	return ""
+}

--- a/internal/view/istio_debug_api.go
+++ b/internal/view/istio_debug_api.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"context"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/derailed/k9s/internal/ui"
@@ -32,7 +33,7 @@ func NewIstioApiView(gvr client.GVR) ResourceViewer {
 func (i *IstioApiView) chartContext(ctx context.Context) context.Context {
 	// 112#istio/config_dump
 	//log.Info().Msgf("GetSelectedItem %s in IstioApiView.chartContext", i.GetTable().GetSelectedItem())
-	return context.WithValue(ctx, "parent", i.GetTable().GetSelectedItem())
+	return context.WithValue(ctx, internal.Parent, i.GetTable().GetSelectedItem())
 }
 
 func (i *IstioApiView) enter(app *App, model ui.Tabular, gvr, path string) {
@@ -57,7 +58,7 @@ func (i *IstioApiView) enter(app *App, model ui.Tabular, gvr, path string) {
 				i.App().Flash().Err(err)
 				return
 			}
-		} else if api == "configzEx"{
+		} else if api == "configzEx" {
 			configzView := NewIstioConfigzView(client.NewGVR("configz"))
 			configzView.SetContextFn(i.chartContext)
 			if err := i.App().inject(configzView); err != nil {

--- a/internal/view/istio_pilot.go
+++ b/internal/view/istio_pilot.go
@@ -3,6 +3,7 @@ package view
 import (
 	"context"
 	"encoding/json"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/derailed/k9s/internal/ui"
@@ -57,7 +58,7 @@ func (i *IstioPodView) chartContext(ctx context.Context) context.Context {
 			log.Error().Msgf("marshal %+v err %s", m, err)
 			return ctx
 		}
-		return context.WithValue(ctx, "parent", string(b))
+		return context.WithValue(ctx, internal.Parent, string(b))
 	}
 	return ctx
 }

--- a/internal/view/istioctl_view.go
+++ b/internal/view/istioctl_view.go
@@ -3,6 +3,7 @@ package view
 import (
 	"context"
 	"fmt"
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/derailed/k9s/internal/ui"
@@ -27,7 +28,7 @@ func NewIstioctlView(gvr client.GVR) ResourceViewer {
 }
 
 func (i *IstioctlView) chartContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, "parent", i.GetTable().GetSelectedItem())
+	return context.WithValue(ctx, internal.Parent, i.GetTable().GetSelectedItem())
 }
 
 func (i *IstioctlView) enter(app *App, model ui.Tabular, gvr, path string) {

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -76,6 +76,7 @@ func (p *Pod) bindKeys(aa ui.KeyActions) {
 		ui.KeyM: ui.NewKeyAction("Envoy-Debug-View", p.showProxyConfig, true),
 		ui.KeyN: ui.NewKeyAction("Istioctl-View", p.showProxyInfo, true),
 		ui.KeyB: ui.NewKeyAction("ProxyEx-View", p.showProxyInfoEx, true),
+		ui.KeyV: ui.NewKeyAction("I9s-Extension", p.i9sExtension, true),
 	})
 	aa.Add(ui.KeyActions{
 		ui.KeyF:      ui.NewKeyAction("Show PortForward", p.showPFCmd, true),
@@ -128,7 +129,10 @@ func (p *Pod) showContainers(app *App, model ui.Tabular, gvr, path string) {
 }
 
 func (p *Pod) coContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, internal.KeyPath, p.GetTable().GetSelectedItem())
+	ctx = context.WithValue(ctx, internal.KeyPath, p.GetTable().GetSelectedItem())
+	ctx = context.WithValue(ctx, internal.IstioRev, p.GetTable().GetSelectedItem())
+	ctx = context.WithValue(ctx, internal.ExtensionType, internal.SidecarView)
+	return ctx
 }
 
 // Handlers...

--- a/internal/view/pod_i9s.go
+++ b/internal/view/pod_i9s.go
@@ -119,3 +119,28 @@ func (p *Pod) containProxy() (bool, bool) {
 
 	return hasProxy, sidecar
 }
+
+func (p *Pod) i9sExtension(evt *tcell.EventKey) *tcell.EventKey {
+	sel := p.GetTable().GetSelectedItem()
+	log.Debug().Msgf("get sel %s in debug", sel)
+	if sel == "" {
+		return evt
+	}
+
+	has, _ := p.containProxy()
+	if !has {
+		log.Debug().Msgf("pod %s has no proxy, skip", sel)
+		return nil
+	}
+
+	env := p.GetTable().envFn()
+	log.Debug().Msgf("get env in pod_i9s %+v", env)
+
+	iview := NewI9sExtensionView(client.NewGVR("i9sExtension"))
+	iview.SetContextFn(p.coContext)
+	if err := p.App().inject(iview); err != nil {
+		p.App().Flash().Err(err)
+		return evt
+	}
+	return nil
+}


### PR DESCRIPTION
you can config `LocalExtensions` in i9s such as:

```
var LocalExtensions = `extensions:
- view: istioView
 name: echo
 command: sh
 args:
 - "echo $ISTIO_REV"
- view: sidecarView
 name: describe
 command: sh
 args:
 - "kubectl describe pods $NAME -n $NAMESPACE"
`
```

- in istioView you can enter ` v` to see all command binding to this view, just like `echo $ISTIO_REV`
- in sidecarView you can enter `v` to see all command binding to this view, just like `kubectl describe pods $NAME -n $NAMESPACE`


Note:

 $ISTIO_REV  $NAMESPACE can use in istioView , and  $ISTIO_REV  $NAMESPACE $NAME can use in sidercarView



